### PR TITLE
Fix image link in high-level-terminology.md

### DIFF
--- a/docs/reference/glossary/high-level-terminology.md
+++ b/docs/reference/glossary/high-level-terminology.md
@@ -11,7 +11,7 @@ The transport layer collects message segments from applications, and transmits t
 
 This layer enables the host to send and receive error corrected data, packets or messages over a network 
 
-[Networking Transport](/img/networking-transport.png)
+![Networking Transport](/img/networking-transport.png)
 
 ## Client Runtime
 


### PR DESCRIPTION
**Select the type of change:**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Small Changes - Typos, formatting, slight revisions
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, and new packages for the site and Docusaurus

**Purpose of the Pull Request:**
The image was added as a regular markdown link instead of an embedded image using `!`


**Issue Number:** 
none
